### PR TITLE
DO NOT MERGE: Force regenerate

### DIFF
--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -58,7 +58,7 @@ jobs:
         S3_ENDPOINT:  ${{ secrets.S3_ENDPOINT }}
         S3_KEY:  ${{ secrets.S3_KEY }}
         S3_SECRET:  ${{ secrets.S3_SECRET }}
-      run: python3 scripts/generate-collection.py --potree --csv
+      run: python3 scripts/generate-collection.py --csv --force
     - name: Save build output
       if: github.ref == 'refs/heads/main'
       uses: actions/upload-artifact@v1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests
 pyyaml
 tqdm
-shareloc-utils[potree]
+shareloc-utils[potree]>=0.1.9
 boto3


### PR DESCRIPTION
This PR is used to regenerate the csv file with the correct header, otherwise the exported csv file won't work with ThunderSTORM.


cc @baiddd 